### PR TITLE
update to allow different resource groups for VNET and AKS

### DIFF
--- a/orc8r/cloud/deploy/azure/arm_templates/gen_template.json
+++ b/orc8r/cloud/deploy/azure/arm_templates/gen_template.json
@@ -30,7 +30,7 @@
         },
         "postgresql_db_server_name": {
             "type": "string",
-            "defaultValue":"orc8r-postgresqldb-01"
+            "defaultValue": "orc8r-postgresqldb-01"
         },
         "postgresdb_admin_login": {
             "type": "string"
@@ -51,8 +51,8 @@
         "virtualNetwork_aksSubnet": {
             "type": "string"
         },
-        "virtualNetwork_dataSubnet":{
-            "type":"string"
+        "virtualNetwork_dataSubnet": {
+            "type": "string"
         },
         "aks_clusterName": {
             "type": "string"
@@ -384,7 +384,7 @@
                 "[resourceId('Microsoft.DBforPostgreSQL/servers', parameters('postgresql_db_server_name'))]"
             ],
             "properties": {
-                "virtualNetworkSubnetId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', parameters('virtualNetwork_name'), '/subnets/',parameters('virtualNetwork_dataSubnet'))]",
+                "virtualNetworkSubnetId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('virtualNetwork_resourceGroup'), '/providers/Microsoft.Network/virtualNetworks/', parameters('virtualNetwork_name'), '/subnets/',parameters('virtualNetwork_dataSubnet'))]",
                 "ignoreMissingVnetServiceEndpoint": false
             }
         },
@@ -396,7 +396,7 @@
                 "[resourceId('Microsoft.DBforMariaDB/servers', parameters('maria_db_server_name'))]"
             ],
             "properties": {
-                "virtualNetworkSubnetId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', parameters('virtualNetwork_name'), '/subnets/',parameters('virtualNetwork_dataSubnet'))]",
+                "virtualNetworkSubnetId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('virtualNetwork_resourceGroup'), '/providers/Microsoft.Network/virtualNetworks/', parameters('virtualNetwork_name'), '/subnets/',parameters('virtualNetwork_dataSubnet'))]",
                 "ignoreMissingVnetServiceEndpoint": false
             }
         }


### PR DESCRIPTION
Updated virtualNetworkRules to use provided value of resource group name for virtual network. This is required to support differing resource groups for the two different ARM templates